### PR TITLE
feat(`Framework`): `commands_vector` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 
 target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,9 @@ members = [
     "zephyrus",
     "zephyrus-macros"
 ]
+resolver = "2"
+
+[workspace.dependencies]
+twilight-model = "0.15"
+twilight-http = "0.15"
+twilight-validate = "0.15"

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Currently, only `String` and `Option<String>` fields are allowed.
 [macro declaration]: https://github.com/AlvaroMS25/zephyrus/blob/master/zephyrus-macros/src/lib.rs#L150-L236
 
 # Bulk Commands Overwrite
-If you'd like to use Discord's [Bulk Overwrite Global Application Commands](https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-global-application-commands) enpoint, perhaps in tandem with a [commands lockfile](https://github.com/carterhimmel/thoth/tree/28c3855b1c55c9ed839bbbcbf9e9c704bf2bd81a/.github/workflows/cd_commands.yml), you'll want to use `Framework#commands_vector`.
+If you'd like to use Discord's [Bulk Overwrite Global Application Commands](https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-global-application-commands) enpoint, perhaps in tandem with a [commands lockfile](https://github.com/carterhimmel/thoth/tree/28c3855b1c55c9ed839bbbcbf9e9c704bf2bd81a/.github/workflows/cd_commands.yml), you'll want to use `Framework#twilight_commands`.
 
 > **Note**
 > This requires the `bulk` feature.
@@ -456,7 +456,7 @@ If you'd like to use Discord's [Bulk Overwrite Global Application Commands](http
 ```rust
 type MyFramework = Arc<Framework<()>>;
 
-async fn create_framework(
+fn create_framework(
     http_client: Arc<Client>,
     app_id: Id<ApplicationMarker>
 ) -> MyFramework {
@@ -466,7 +466,7 @@ async fn create_framework(
 }
 
 fn create_lockfile(framework: MyFramework) -> Result<()> {
-    let commands = framework.commands_vector();
+    let commands = framework.twilight_commands();
     let content = serde_json::to_string_pretty(&commands)?;
 
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/commands.lock.json").to_string();

--- a/README.md
+++ b/README.md
@@ -446,3 +446,44 @@ shown to the user using the `#[modal(..)}` attributes. To see the full list of a
 Currently, only `String` and `Option<String>` fields are allowed.
 
 [macro declaration]: https://github.com/AlvaroMS25/zephyrus/blob/master/zephyrus-macros/src/lib.rs#L150-L236
+
+# Bulk Commands Overwrite
+If you'd like to use Discord's [Bulk Overwrite Global Application Commands](https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-global-application-commands) enpoint, perhaps in tandem with a [commands lockfile](https://github.com/carterhimmel/thoth/tree/28c3855b1c55c9ed839bbbcbf9e9c704bf2bd81a/.github/workflows/cd_commands.yml), you'll want to use `Framework#commands_vector`.
+
+> **Note**
+> This requires the `bulk` feature.
+
+```rust
+type MyFramework = Arc<Framework<()>>;
+
+async fn create_framework(
+    http_client: Arc<Client>,
+    app_id: Id<ApplicationMarker>
+) -> MyFramework {
+    Arc::new(Framework::builder(http_client, app_id, ())
+        .command(hello)
+        .build())
+}
+
+fn create_lockfile(framework: MyFramework) -> Result<()> {
+    let commands = framework.commands_vector();
+    let content = serde_json::to_string_pretty(&commands)?;
+
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/commands.lock.json").to_string();
+	std::fs::write(path, content).unwrap();
+
+    Ok(())
+}
+```
+
+<!-- # Unsupported Message and User Commands
+Zephyrus [doesn't quite support message and user commands](https://github.com/AlvaroMS25/zephyrus/issues/6).  
+
+If you want to:
+- use message/user commands
+- utilize [Bulk Overwrite Global Application Commands]()
+- and utilize a [Commands Lockfile]()  
+
+you'll have to:
+- selectively filter which `INTERACTION_CREATE` [types](https://docs.rs/twilight-model/0.15.2/twilight_model/application/interaction/enum.InteractionType.html) are fed to Zephyrus
+- exclusively use Zephyrus' modal system or your own, not both -->

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 futures-util = "0.3"
 rand = "0.8"
 tokio = { version = "1", features = ["full"]}
-twilight-http = "0.15.0"
-twilight-model = "0.15.0"
+twilight-http = { workspace = true }
+twilight-model = { workspace = true }
 twilight-gateway = "0.15.0"
 zephyrus = { path = "../zephyrus" }
 

--- a/zephyrus/Cargo.toml
+++ b/zephyrus/Cargo.toml
@@ -21,9 +21,12 @@ async-trait = "0.1"
 zephyrus-macros = { path = "../zephyrus-macros", version = "0.9" }
 parking_lot = "0.12"
 tracing = "0.1"
-twilight-model = "0.15"
-twilight-http = "0.15"
-twilight-validate = "0.15"
+twilight-model = { workspace = true }
+twilight-http = { workspace = true }
+twilight-validate = { workspace = true }
+
+# feature: bulk
+twilight-util = { version = "0.15", features = ["builder"], optional = true }
 
 [dependencies.tokio]
 version = "1"
@@ -32,6 +35,7 @@ features = ["sync"]
 
 [features]
 rc = []
+bulk = ["dep:twilight-util"]
 
 [dev-dependencies]
 futures = "0.3"

--- a/zephyrus/src/framework.rs
+++ b/zephyrus/src/framework.rs
@@ -406,7 +406,7 @@ where
     #[cfg(feature = "bulk")]
     pub fn commands_vector(
         &self,
-    ) -> Result<Vec<TwilightCommand>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Vec<TwilightCommand> {
         use twilight_model::application::command::CommandType;
         use twilight_util::builder::command::CommandBuilder;
 
@@ -442,7 +442,7 @@ where
             commands.push(command.build());
         }
 
-        Ok(commands)
+        commands
     }
 
     fn arg_options(&self, arguments: &Vec<CommandArgument<D>>) -> Vec<CommandOption> {

--- a/zephyrus/src/framework.rs
+++ b/zephyrus/src/framework.rs
@@ -402,9 +402,9 @@ where
         Ok(commands)
     }
 
-    /// Creates a vector of Command objects, to be used against Discord's bulk endpoint.
+    /// Creates a vector of Twilight [`Command`](twilight_model::application::command::Command) objects, to be used against Discord's bulk endpoint.
     #[cfg(feature = "bulk")]
-    pub fn commands_vector(
+    pub fn twilight_commands(
         &self,
     ) -> Vec<TwilightCommand> {
         use twilight_model::application::command::CommandType;


### PR DESCRIPTION
This PR:
- creates `Framework#commands_vector`, a function to create a vector of `Commands`, than can be passed into `serde_json` to create a JSON string
- uses `[workspace.dependencies]` in the root for some reused dependencies