### PR TITLE
chore(Framework): update `twilight_commands` for user/message commands

### DIFF
--- a/zephyrus/src/framework.rs
+++ b/zephyrus/src/framework.rs
@@ -380,9 +380,7 @@ where
             if_some!(&cmd.localized_names, |n| command = command.name_localizations(n));
             if_some!(&cmd.localized_descriptions, |d| command = command.name_localizations(d));
 
-            if let Some(permissions) = &cmd.required_permissions {
-                command = command.default_member_permissions(*permissions);
-            }
+            if_some!(cmd.required_permissions, |p| command = command.default_member_permissions(p));
 
             commands.push(command.build());
         }

--- a/zephyrus/src/framework.rs
+++ b/zephyrus/src/framework.rs
@@ -17,6 +17,7 @@ use tracing::debug;
 use parking_lot::Mutex;
 use crate::command::ExecutionResult;
 use crate::parse::ParseError;
+use crate::if_some;
 
 macro_rules! extract {
     ($expr:expr => $variant:ident) => {
@@ -369,11 +370,15 @@ where
 
         for cmd in self.commands.values() {
             // FIXME: support more than just chat input
-            let mut command = CommandBuilder::new(cmd.name, cmd.description, CommandType::ChatInput);
+            let mut command = CommandBuilder::new(cmd.name, cmd.description, cmd.kind);
 
             for i in &cmd.arguments {
                 command = command.option(i.as_option());
             }
+
+            if_some!(cmd.required_permissions, |p| command = command.default_member_permissions(p));
+            if_some!(&cmd.localized_names, |n| command = command.name_localizations(n));
+            if_some!(&cmd.localized_descriptions, |d| command = command.name_localizations(d));
 
             if let Some(permissions) = &cmd.required_permissions {
                 command = command.default_member_permissions(*permissions);
@@ -384,15 +389,14 @@ where
 
         for group in self.groups.values() {
             let options = group.get_options();
+            // groups are only supported by chat input
             let mut command = CommandBuilder::new(group.name, group.description, CommandType::ChatInput);
 
             for i in options {
                 command = command.option(i);
             }
 
-            if let Some(permissions) = &group.required_permissions {
-                command = command.default_member_permissions(*permissions);
-            }
+            if_some!(group.required_permissions, |p| command = command.default_member_permissions(p));
 
             commands.push(command.build());
         }


### PR DESCRIPTION
This PR:
- updates `Framework#twilight_commands` to support message and user commands