### PR TITLE
Prevent misaligned pointer dereference in Range

### DIFF
--- a/vesper/src/context.rs
+++ b/vesper/src/context.rs
@@ -113,6 +113,7 @@ impl<'a, D> SlashContext<'a, D> {
         #[allow(invalid_reference_casting)]
         let ptr_mut = &self.interaction as *const Interaction as *mut Interaction;
 
+        #[allow(invalid_reference_casting)]
         unsafe { &mut *(ptr_mut) }
     }
 

--- a/vesper/src/range.rs
+++ b/vesper/src/range.rs
@@ -10,12 +10,18 @@ mod sealed {
     use super::*;
 
     /// A trait used to specify the values [range](super::Range) can take.
-    pub trait Number: Copy + Debug + Display {}
+    pub trait Number: Copy + Debug + Display {
+        fn as_i64(&self) -> i64;
+    }
 
     macro_rules! number {
         ($($t:ty),* $(,)?) => {
             $(
-                impl Number for $t {}
+                impl Number for $t {
+                    fn as_i64(&self) -> i64 {
+                        *self as i64
+                    }
+                }
             )*
         };
     }
@@ -60,9 +66,7 @@ impl<T, E, const START: i64, const END: i64> Parse<T> for Range<E, START, END>
     ) -> Result<Self, ParseError> {
         let value = E::parse(http_client, data, value, resolved).await?;
 
-        // SAFETY: Both the upper and lower values must be i64's and the Number trait is implemented
-        // only for integer numbers, so casting the value to an i64 is safe to do.
-        let v = unsafe { *(&value as *const E as *const i64) };
+        let v = value.as_i64();
 
         if v < START || v > END {
             return Err(error(


### PR DESCRIPTION
Using a `Range<u16, 1, 1000>` as a command argument panics with the following error: `misaligned pointer dereference: address must be a multiple of 0x8 but is 0x8442bdbfae`.

This PR should fix this.

Note that to be able to compile the project locally, I had to add an additional `#[allow(invalid_reference_casting)]` in the context.rs file.