### PR TITLE
Do not parse arguments in a command that has none

### DIFF
--- a/vesper-macros/src/command/mod.rs
+++ b/vesper-macros/src/command/mod.rs
@@ -98,28 +98,30 @@ pub fn parse_arguments(
             .collect::<Vec<_>>(),
     );
 
-    // The original block of the function
-    let b = &block;
+    if !names.is_empty() {
+        // The original block of the function
+        let b = &block;
 
-    // Modify the block to parse arguments
-    *block = parse2(quote::quote! {{
-        let (#(#names),*) = {
-            let mut __options = ::vesper::iter::DataIterator::new(#ctx_ident);
+        // Modify the block to parse arguments
+        *block = parse2(quote::quote! {{
+            let (#(#names),*) = {
+                let mut __options = ::vesper::iter::DataIterator::new(#ctx_ident);
 
-            #(let #names =
-                __options.named_parse::<#types>(#renames).await?;)*
+                #(let #names =
+                    __options.named_parse::<#types>(#renames).await?;)*
 
-            if __options.len() > 0 {
-                return Err(
-                    ::vesper::prelude::ParseError::StructureMismatch("Too many arguments received".to_string()).into()
-                );
-            }
+                if __options.len() > 0 {
+                    return Err(
+                        ::vesper::prelude::ParseError::StructureMismatch("Too many arguments received".to_string()).into()
+                    );
+                }
 
-            (#(#names),*)
-        };
+                (#(#names),*)
+            };
 
-        #b
-    }})?;
+            #b
+        }})?;
+    }
 
     Ok(arguments)
 }


### PR DESCRIPTION
In `#[command]`s that don't take any arguments, `parse_arguments` was still emitting argument parsing code. Not only did this needlessly output unused code, but Clippy was emitting an annoying `unneeded unit expression` warning that I couldn't `#[allow]`! 🙃